### PR TITLE
update for newest pandoc's +smart syntax

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,14 +26,14 @@ done
 
 # EPUB
 if [ $ALL == 'true' ] || [ $EPUB == 'true' ] ; then
-	pandoc assets/metadata.yml chapters/*.md -o $TITLE.epub -S
+	pandoc assets/metadata.yml chapters/*.md -o $TITLE.epub -t epub+smart
 fi
 
 
 # PDF
 if [ $ALL == 'true' ] || [ $PDF == 'true' ] ; then
 	## Temp PDF
-	pandoc assets/title.md assets/toc.md chapters/*.md assets/scripts.md -o $TITLE-temp.pdf -t html5 -S -V papersize:"letter" -c assets/pandoc.css
+	pandoc assets/title.md assets/toc.md chapters/*.md assets/scripts.md -o $TITLE-temp.pdf -t html5+smart -V papersize:"letter" -c assets/pandoc.css --metadata pagetitle="$TITLE"
 
 	## Merge Cover
 	if [ $COVER == 'true' ] ; then
@@ -58,7 +58,7 @@ fi
 
 # HTML
 if [ $ALL == 'true' ] || [ $HTML == 'true' ] ; then
-	pandoc -H assets/pandoc-before.css -H assets/pandoc.css -H assets/pdf-overrides.css -H assets/pandoc-after.css assets/title.md assets/toc.md chapters/*.md assets/scripts.md -o $TITLE.html -S
+	pandoc -H assets/pandoc-before.css -H assets/pandoc.css -H assets/pdf-overrides.css -H assets/pandoc-after.css assets/title.md assets/toc.md chapters/*.md assets/scripts.md -o $TITLE.html -t html5+smart --metadata pagetitle="$TITLE"
 fi
 
 # Zip


### PR DESCRIPTION
This PR changes to the new pandoc syntax for smart quotes.

The most recent pandoc changes from using the `-S` flag for handling smart quotes to using `+smart` or `-smart` prefixes on the `-f` (from) and `-t` (to) format keywords.

e.g. `-t epub+smart` (to epub with smart quotes support)

Additionally, this PR adds `--metadata pagetitle="$TITLE"` to suppress a warning for html output. Might need to add a new variable to allot customizing the html page title.